### PR TITLE
Update ProphET_standalone.pl RealBin

### DIFF
--- a/ProphET_standalone.pl
+++ b/ProphET_standalone.pl
@@ -6,7 +6,7 @@ use Pod::Usage;
 use Getopt::Long;
 use FindBin;
 
-use lib "$FindBin::Bin/UTILS.dir/GFFLib"; 
+use lib "$FindBin::RealBin/UTILS.dir/GFFLib"; 
 
 use GFFFile;
 


### PR DESCRIPTION
Changed GFFLib import to look in the physical location of the ProphET_standalone.pl script using FindBin::RealBin. Currently the code uses FindBin::Bin which will not follow symbolic links.

Checked with ProphET_standalone.pl -h but not much further...